### PR TITLE
Add persisted addition logic with unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sfx-o-assign2-persisted-addition",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/persisted-addition.html
+++ b/persisted-addition.html
@@ -21,34 +21,6 @@
         </div>
     </div>
 
-    <script>
-        const numberInput = document.getElementById('numberInput');
-        const addButton = document.getElementById('addButton');
-        const numberList = document.getElementById('numberList');
-        const totalSum = document.getElementById('totalSum');
-    
-        let enteredNumbers = [];
-        let sum = 0;
-    
-        addButton.addEventListener('click', function () {
-            const number = numberInput.value.trim();
-
-            // Check if input is a valid integer (no decimals, no empty input)
-            if (!/^-?\d+$/.test(number)) { 
-                alert('Please enter a valid integer.');
-                return;
-            }
-
-            const numValue = parseInt(number, 10);
-            enteredNumbers.push(numValue);
-            sum += numValue;
-
-            numberList.textContent = enteredNumbers.join(' + ');
-            totalSum.textContent = sum;
-
-            numberInput.value = '';
-            numberInput.focus();
-        });
-    </script>
+    <script type="module" src="./persisted-addition.js"></script>
 </body>
 </html>

--- a/persisted-addition.js
+++ b/persisted-addition.js
@@ -1,0 +1,28 @@
+import { updatePersistedNumbersAndSum } from './persisted-store.js';
+
+const numberInput = document.getElementById('numberInput');
+const addButton = document.getElementById('addButton');
+const numberList = document.getElementById('numberList');
+const totalSum = document.getElementById('totalSum');
+
+function renderResult(result) {
+    numberList.textContent = result.numbers.join(' + ');
+    totalSum.textContent = result.sum;
+}
+
+renderResult(updatePersistedNumbersAndSum(localStorage));
+
+addButton.addEventListener('click', function () {
+    const number = numberInput.value.trim();
+
+    if (!/^-?\d+$/.test(number)) {
+        alert('Please enter a valid integer.');
+        return;
+    }
+
+    const numValue = parseInt(number, 10);
+    renderResult(updatePersistedNumbersAndSum(localStorage, numValue));
+
+    numberInput.value = '';
+    numberInput.focus();
+});

--- a/persisted-store.js
+++ b/persisted-store.js
@@ -1,0 +1,24 @@
+export const STORAGE_KEY = 'enteredNumbers';
+
+export function updatePersistedNumbersAndSum(storage, nextNumber) {
+    const storedValue = storage.getItem(STORAGE_KEY);
+    let parsedValue = [];
+
+    try {
+        parsedValue = JSON.parse(storedValue ?? '[]');
+    } catch {
+        parsedValue = [];
+    }
+
+    const numbers = Array.isArray(parsedValue) ? parsedValue : [];
+
+    if (Number.isInteger(nextNumber)) {
+        numbers.push(nextNumber);
+    }
+
+    storage.setItem(STORAGE_KEY, JSON.stringify(numbers));
+
+    const sum = numbers.reduce((total, number) => total + number, 0);
+
+    return { numbers, sum };
+}

--- a/persisted-store.test.js
+++ b/persisted-store.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { STORAGE_KEY, updatePersistedNumbersAndSum } from './persisted-store.js';
+
+function createFakeStorage(initialValues = {}) {
+    const state = { ...initialValues };
+
+    return {
+        getItem(key) {
+            return Object.prototype.hasOwnProperty.call(state, key) ? state[key] : null;
+        },
+        setItem(key, value) {
+            state[key] = String(value);
+        },
+    };
+}
+
+test('reads persisted numbers and returns their sum', function () {
+    const storage = createFakeStorage({
+        [STORAGE_KEY]: JSON.stringify([1, 2, 3]),
+    });
+
+    const result = updatePersistedNumbersAndSum(storage);
+
+    assert.deepEqual(result.numbers, [1, 2, 3]);
+    assert.equal(result.sum, 6);
+});
+
+test('appends new integer, persists it, and returns updated sum', function () {
+    const storage = createFakeStorage({
+        [STORAGE_KEY]: JSON.stringify([4, 5]),
+    });
+
+    const result = updatePersistedNumbersAndSum(storage, -2);
+
+    assert.deepEqual(result.numbers, [4, 5, -2]);
+    assert.equal(result.sum, 7);
+    assert.equal(storage.getItem(STORAGE_KEY), JSON.stringify([4, 5, -2]));
+});
+
+test('handles missing storage value as empty list', function () {
+    const storage = createFakeStorage();
+
+    const result = updatePersistedNumbersAndSum(storage);
+
+    assert.deepEqual(result.numbers, []);
+    assert.equal(result.sum, 0);
+    assert.equal(storage.getItem(STORAGE_KEY), JSON.stringify([]));
+});
+
+test('handles invalid JSON in storage as empty list', function () {
+    const storage = createFakeStorage({
+        [STORAGE_KEY]: 'not-json',
+    });
+
+    const result = updatePersistedNumbersAndSum(storage);
+
+    assert.deepEqual(result.numbers, []);
+    assert.equal(result.sum, 0);
+    assert.equal(storage.getItem(STORAGE_KEY), JSON.stringify([]));
+});


### PR DESCRIPTION
## Summary
- move inline script to module-based JS
- add a single function that reads/writes persisted numbers and computes sum
- load persisted values on page load and keep integer validation
- add unit tests for persistence and sum behavior

## Verification
- npm test