### PR TITLE
Persist added numbers and add unit tests

### DIFF
--- a/numberStorageService.js
+++ b/numberStorageService.js
@@ -1,0 +1,27 @@
+const STORAGE_KEY = "persistedNumbers";
+
+function handlePersistedNumbers(storage, numberToAdd) {
+    const storedNumbers = storage.getItem(STORAGE_KEY);
+    const numbers = storedNumbers ? JSON.parse(storedNumbers) : [];
+
+    if (numberToAdd !== undefined) {
+        numbers.push(numberToAdd);
+        storage.setItem(STORAGE_KEY, JSON.stringify(numbers));
+    }
+
+    const sum = numbers.reduce(function (total, number) {
+        return total + number;
+    }, 0);
+
+    return {
+        numbers: numbers,
+        sum: sum
+    };
+}
+
+if (typeof module !== "undefined") {
+    module.exports = {
+        handlePersistedNumbers,
+        STORAGE_KEY
+    };
+}

--- a/numberStorageService.test.js
+++ b/numberStorageService.test.js
@@ -1,0 +1,54 @@
+const { handlePersistedNumbers, STORAGE_KEY } = require("./numberStorageService");
+
+describe("handlePersistedNumbers", function () {
+    let fakeStorage;
+
+    beforeEach(function () {
+        let storageData = {};
+
+        fakeStorage = {
+            getItem: function (key) {
+                return storageData[key] || null;
+            },
+            setItem: function (key, value) {
+                storageData[key] = value;
+            }
+        };
+    });
+
+    test("should add one number and return the correct sum", function () {
+        // Arrange
+        const numberToAdd = 5;
+
+        // Act
+        const result = handlePersistedNumbers(fakeStorage, numberToAdd);
+
+        // Assert
+        expect(result.numbers).toEqual([5]);
+        expect(result.sum).toBe(5);
+    });
+
+    test("should add a number to already saved numbers and return the correct sum", function () {
+        // Arrange
+        fakeStorage.setItem(STORAGE_KEY, JSON.stringify([5, 10]));
+
+        // Act
+        const result = handlePersistedNumbers(fakeStorage, 3);
+
+        // Assert
+        expect(result.numbers).toEqual([5, 10, 3]);
+        expect(result.sum).toBe(18);
+    });
+
+    test("should read saved numbers without adding a new number", function () {
+        // Arrange
+        fakeStorage.setItem(STORAGE_KEY, JSON.stringify([2, 4, 6]));
+
+        // Act
+        const result = handlePersistedNumbers(fakeStorage);
+
+        // Assert
+        expect(result.numbers).toEqual([2, 4, 6]);
+        expect(result.sum).toBe(12);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
Implemented persistence for inserted numbers using localStorage.
Moved the read/write and sum logic into a testable function.
Added unit tests for the persistence and summarizing logic.

Note: I could not run npm test locally because Node.js/npm is not available on my PC.